### PR TITLE
Небольшие фиксы

### DIFF
--- a/src/main/java/ru/mrbrikster/chatty/listeners/ChatListener.java
+++ b/src/main/java/ru/mrbrikster/chatty/listeners/ChatListener.java
@@ -332,7 +332,7 @@ public abstract class ChatListener implements Listener {
             String replacement = configuration.getNode("moderation.swear.replacement").getAsString("<swear>");
             List<String> swears = pendingSwears.remove(playerChatEvent.getPlayer());
 
-            if (player.hasPermission("chatty.swears.see")) {
+            if (swears != null && player.hasPermission("chatty.swears.see")) {
                 List<String> swearTooltip = configuration.getNode("json.swears.tooltip").getAsStringList()
                         .stream().map(tooltipLine -> ChatColor.translateAlternateColorCodes('&', tooltipLine)).collect(Collectors.toList());
 

--- a/src/main/java/ru/mrbrikster/chatty/listeners/ChatListener.java
+++ b/src/main/java/ru/mrbrikster/chatty/listeners/ChatListener.java
@@ -159,7 +159,7 @@ public abstract class ChatListener implements Listener {
 
         if (!hasCooldown) chat.setCooldown(player);
 
-        String logPrefix = "";
+        StringBuilder logPrefixBuilder = new StringBuilder();
         if (moderationManager.isSwearModerationEnabled()) {
             SwearModerationMethod swearMethod = moderationManager.getSwearMethod(message);
             if (!player.hasPermission("chatty.moderation.swear")) {
@@ -168,7 +168,7 @@ public abstract class ChatListener implements Listener {
                         event.getRecipients().clear();
                         event.getRecipients().add(player);
 
-                        logPrefix = "[SWEAR] ";
+                        logPrefixBuilder.append("[SWEAR] ");
                     } else {
                         message = swearMethod.getEditedMessage();
                     }
@@ -195,7 +195,7 @@ public abstract class ChatListener implements Listener {
                         event.getRecipients().clear();
                         event.getRecipients().add(player);
 
-                        logPrefix = "[CAPS] ";
+                        logPrefixBuilder.append("[CAPS] ");
                     } else {
                         message = capsMethod.getEditedMessage();
                     }
@@ -217,7 +217,7 @@ public abstract class ChatListener implements Listener {
                         event.getRecipients().clear();
                         event.getRecipients().add(player);
 
-                        logPrefix = "[ADS] ";
+                        logPrefixBuilder.append("[ADS] ");
                     } else {
                         message = advertisementMethod.getEditedMessage();
                     }
@@ -233,7 +233,7 @@ public abstract class ChatListener implements Listener {
 
         event.setMessage(message);
         pendingPlayers.put(player, chat);
-        this.chatManager.getLogger().write(player, message, logPrefix);
+        this.chatManager.getLogger().write(player, message, logPrefixBuilder.toString());
     }
 
     @EventHandler(priority = EventPriority.MONITOR)

--- a/src/main/java/ru/mrbrikster/chatty/listeners/ChatListener.java
+++ b/src/main/java/ru/mrbrikster/chatty/listeners/ChatListener.java
@@ -159,18 +159,21 @@ public abstract class ChatListener implements Listener {
 
         if (!hasCooldown) chat.setCooldown(player);
 
+        boolean blocked = false;
         StringBuilder logPrefixBuilder = new StringBuilder();
         if (moderationManager.isSwearModerationEnabled()) {
             SwearModerationMethod swearMethod = moderationManager.getSwearMethod(message);
             if (!player.hasPermission("chatty.moderation.swear")) {
                 if (swearMethod.isBlocked()) {
+
+                    message = swearMethod.getEditedMessage();
                     if (swearMethod.isUseBlock()) {
                         event.getRecipients().clear();
                         event.getRecipients().add(player);
 
+                        blocked = true;
+
                         logPrefixBuilder.append("[SWEAR] ");
-                    } else {
-                        message = swearMethod.getEditedMessage();
                     }
 
                     String swearFound = Configuration.getMessages().get("swear-found", null);
@@ -191,13 +194,15 @@ public abstract class ChatListener implements Listener {
             CapsModerationMethod capsMethod = this.moderationManager.getCapsMethod(message);
             if (!player.hasPermission("chatty.moderation.caps")) {
                 if (capsMethod.isBlocked()) {
+
+                    message = capsMethod.getEditedMessage();
                     if (capsMethod.isUseBlock()) {
                         event.getRecipients().clear();
                         event.getRecipients().add(player);
 
+                        blocked = true;
+
                         logPrefixBuilder.append("[CAPS] ");
-                    } else {
-                        message = capsMethod.getEditedMessage();
                     }
 
                     String capsFound = Configuration.getMessages().get("caps-found", null);
@@ -213,13 +218,15 @@ public abstract class ChatListener implements Listener {
             AdvertisementModerationMethod advertisementMethod = this.moderationManager.getAdvertisementMethod(message);
             if (!player.hasPermission("chatty.moderation.advertisement")) {
                 if (advertisementMethod.isBlocked()) {
+
+                    message = advertisementMethod.getEditedMessage();
                     if (advertisementMethod.isUseBlock()) {
                         event.getRecipients().clear();
                         event.getRecipients().add(player);
 
+                        blocked = true;
+
                         logPrefixBuilder.append("[ADS] ");
-                    } else {
-                        message = advertisementMethod.getEditedMessage();
                     }
 
                     String adsFound = Configuration.getMessages().get("advertisement-found", null);
@@ -229,6 +236,10 @@ public abstract class ChatListener implements Listener {
                                 () -> player.sendMessage(adsFound), 5L);
                 }
             }
+        }
+
+        if (blocked) {
+            event.setCancelled(true);
         }
 
         event.setMessage(message);

--- a/src/main/java/ru/mrbrikster/chatty/moderation/AdvertisementModerationMethod.java
+++ b/src/main/java/ru/mrbrikster/chatty/moderation/AdvertisementModerationMethod.java
@@ -48,11 +48,16 @@ public class AdvertisementModerationMethod extends ModerationMethod {
             return this.result;
         }
 
+        if (this.editedMessage == null) {
+            this.editedMessage = this.message;
+        }
+
         this.result = match(ipPattern, string -> string);
         this.result = match(webPattern, string -> string
                 .replaceAll(Pattern.quote("www."), "")
                 .replaceAll(Pattern.quote("http://"), "")
-                .replaceAll(Pattern.quote("https://"), ""));
+                .replaceAll(Pattern.quote("https://"), "")
+        ) || this.result;
 
         this.checked = true;
 
@@ -60,7 +65,7 @@ public class AdvertisementModerationMethod extends ModerationMethod {
     }
 
     private boolean match(Pattern pattern, Function<String, String> modifyFunction) {
-        Matcher matcher = pattern.matcher(this.message);
+        Matcher matcher = pattern.matcher(this.editedMessage);
 
         int prevIndex = 0;
         StringBuilder builder = new StringBuilder();
@@ -69,21 +74,21 @@ public class AdvertisementModerationMethod extends ModerationMethod {
         while (matcher.find()) {
             String group = matcher.group();
 
-            builder.append(this.message, prevIndex, matcher.start());
+            builder.append(this.editedMessage, prevIndex, matcher.start());
             prevIndex = matcher.end();
 
             String ad = modifyFunction.apply(group.trim().toLowerCase());
 
             if (this.whitelist.contains(ad)) {
-                builder.append(this.message, matcher.start(), matcher.end());
+                builder.append(this.editedMessage, matcher.start(), matcher.end());
             } else {
                 containsAds = true;
                 builder.append(this.replacement);
             }
         }
 
-        if (prevIndex < this.message.length()) {
-            builder.append(this.message, prevIndex, this.message.length());
+        if (prevIndex < this.editedMessage.length()) {
+            builder.append(this.editedMessage, prevIndex, this.editedMessage.length());
         }
 
         this.editedMessage = builder.toString();


### PR DESCRIPTION
Если заблокировался мат, капс или реклама, то устанавливался последний префикс, например, игрок написал сообщение "ЗАХОДИ НА МОЙ СЕРВЕР MINECRAFT.NET", то префикс был бы "[ADS] ...". Этот фикс пишет все префиксы для всех блокировок, например, "[CAPS] [ADS] ..."

Фикс для плагина "DiscordSRV". Если в конфиге прописано "block: true", то сообщение отменяется. Из-за отмены сообщения, игрок больше не видит своего сообщения, но ему по прежнему пишет о "нарушении правил".

Фикс нулл поинтера
Если у тебя были права, чтобы нарушать "правила"(Маты, капс или реклама), то вылетал нулл поинтер.

Фикс замены "рекламы" на другое слово.
Если написать в чате "127.168.0.0 minecraft.net", то блокировалось только второй адрес, так как изменения первого перезаписывались.